### PR TITLE
Remove semicolons from SQL queries when compiling joint queries

### DIFF
--- a/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdReferencingObjectMap.java
+++ b/src/main/java/net/antidot/semantic/rdf/rdb2rdf/r2rml/model/StdReferencingObjectMap.java
@@ -53,9 +53,20 @@ public class StdReferencingObjectMap implements ReferencingObjectMap {
 		this.joinConditions.addAll(joinConditions);
 	}
 
+	private String removeSemicolon(String str) {
+// Removes semicolon at the end of SQL expressions
+		if (str != null && str.trim().length() > 0 ){
+			str = str.trim();
+			if (str.charAt(str.length() - 1) == ';') {
+				str = str.substring(0, str.length() - 1);
+			}
+		}
+		return str;
+	}
+
 	public String getChildQuery() {
-		return predicateObjectMap.getOwnTriplesMap().getLogicalTable()
-				.getEffectiveSQLQuery();
+		return removeSemicolon(predicateObjectMap.getOwnTriplesMap().getLogicalTable()
+				.getEffectiveSQLQuery());
 	}
 
 	public Set<JoinCondition> getJoinConditions() {
@@ -86,7 +97,7 @@ public class StdReferencingObjectMap implements ReferencingObjectMap {
 	}
 
 	public String getParentQuery() {
-		return parentTriplesMap.getLogicalTable().getEffectiveSQLQuery();
+		return removeSemicolon(parentTriplesMap.getLogicalTable().getEffectiveSQLQuery());
 	}
 
 	public TriplesMap getParentTriplesMap() {


### PR DESCRIPTION
The official R2RML documentation ( https://www.w3.org/TR/r2rml/ ) provides examples of rr:sqlQuery with semicolons at the end of SQL queries. This results in errors in db2triples when one or more instances of rr:sqlQuery is joined using rr:joinCondition, because db2triples  does not remove semicolons from child and parent SQL queries. A solution is removing semicolons from SQL queries.